### PR TITLE
Rename github clone paths from 'git@github.com:' to 'https://github.c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ You can download the manual from [Leanpub](http://leanpub.com/pragmatic_virtuali
 
 ## Get the extra content
 
-    git clone git@github.com:damko/pragmatic_virtualization_extra.git
+    git clone https://github.com/damko/pragmatic_virtualization_extra.git

--- a/manuscript/ch1/1.1.0.0-get_ready.txt
+++ b/manuscript/ch1/1.1.0.0-get_ready.txt
@@ -25,7 +25,7 @@ Once Git is installed you are ready to download the _extra_ repository:
 {linenos=off, lang=bash}
 ~~~~~~~
     cd <your-favorite-directory>
-    git clone git@github.com:damko/pragmatic_virtualization_extra.git
+    git clone https://github.com/damko/pragmatic_virtualization_extra.git
 ~~~~~~~
 
 This will create the `pragmatic_virtualization_extra` subdirectory inside `your-favorite-directory`.

--- a/manuscript/ch2/2.4.0.0-create_vagrant_box_from_cloud.txt
+++ b/manuscript/ch2/2.4.0.0-create_vagrant_box_from_cloud.txt
@@ -17,7 +17,7 @@ To use this box run:
 {linenos=off, lang=bash}
 ~~~~~~~
 cd $pve/ariadne/orchestration/vagrant
-vagrant init deb/jessie-amd64 --provider virtualbox
+vagrant init deb/jessie-amd64
 ~~~~~~~
 
 Output:

--- a/manuscript/ch3/3.2.0.0-improving_vagrantfile.txt
+++ b/manuscript/ch3/3.2.0.0-improving_vagrantfile.txt
@@ -6,24 +6,12 @@ The Vagrantfile can be written to configure several virtual machines and to host
 
 The _improving_vagrantfile_ _extra_ branch has an improved version of the previous Vagrantfile but before doing anything you need to backup your `.vagrant` directory because it contains some important and unique information about your vagrant virtual machine.
 
-{linenos=off, lang=bash}
-~~~~~~~
-cp -fR $pve/ariadne/orchestration/vagrant/.vagrant /tmp/
-~~~~~~~
-
-Now you should checkout the _create_vagrant_box_from_iso_ branch from the _extra_ repository:
+You should checkout the _improving_vagrantfile_ branch from the _extra_ repository:
 
 {linenos=off, lang=bash}
 ~~~~~~~
 cd $pve
 git checkout improving_vagrantfile
-~~~~~~~
-
-and finally restore your `.vagrant` directory:
-
-{linenos=off, lang=bash}
-~~~~~~~
-mv /tmp/.vagrant $pve/ariadne/orchestration/vagrant/
 ~~~~~~~
 
 Now have a look at the Vagrantfile provided with this branch. It looks like this:

--- a/manuscript/ch5/5.1.0.0-suggestotron.txt
+++ b/manuscript/ch5/5.1.0.0-suggestotron.txt
@@ -83,7 +83,7 @@ Checkout the _suggestotron_database_creation_ branch from the _extra_ repository
 {linenos=off, lang=bash}
 ~~~~~~~
 cd $pve
-git checkout suggestotron_database_creation
+git checkout suggestotron_populate_db
 ~~~~~~~
 
 Now you see some more files
@@ -187,7 +187,7 @@ Let's see if it's true with this command:
 
 {linenos=off, lang=bash}
 ~~~~~~~
-ssh vagrant@ariadne-dev 'echo "select * from topics" | mysql -uroot -proot' suggestotron
+ssh vagrant@ariadne-dev 'echo "select * from topics" | mysql -uroot -proot suggestotron'
 #provide "vagrant" as password
 ~~~~~~~
 
@@ -207,8 +207,8 @@ The [Suggestroton repository](https://github.com/dshafik/suggestotron) uses tags
 
 {linenos=off, lang=bash}
 ~~~~~~~
-cd $pve/ariadne-dev/projects
-git clone git@github.com:dshafik/suggestotron.git
+cd $pve/ariadne/projects
+git clone https://github.com/dshafik/suggestotron.git
 ~~~~~~~
 
 What has been done till now is roughly the equivalent of the first 6 chapters of the Suggestron guide so you should checkout the Suggestotron code at chapter 7 level.
@@ -292,7 +292,7 @@ Just add this line to the `/etc/hosts` file in your workstation
 
 {linenos=off, lang=bash}
 ~~~~~~~
-192.168.51.10    suggestotron.dev www.suggestotron.dev
+192.168.51.10    suggestotron.ariadne-dev www.suggestotron.ariadne-dev
 ~~~~~~~
 
 Now open this link [http://suggestotron.ariadne-dev](http://suggestotron.ariadne-dev) and you should see this:


### PR DESCRIPTION
…om/'.

Remove '--provider virtualbox' from 'vagrant init' command in 2.4.0.0.
Remove cp/mv commands in 3.2.0.0 (.vagrant directory stays the same when changing branches).
Some small fixes.
